### PR TITLE
feat(gha): add CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,34 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "20:00"
-  open-pull-requests-limit: 10
-  reviewers:
-  - taiyoh
-  assignees:
-  - taiyoh
-  ignore:
-  - dependency-name: github.com/aws/aws-sdk-go
-    versions:
-    - "> 1.29.19, < 1.30"
-  - dependency-name: github.com/aws/aws-sdk-go
-    versions:
-    - "> 1.30.5, < 1.31"
-  - dependency-name: github.com/aws/aws-sdk-go
-    versions:
-    - "> 1.32.2, < 1.33"
-  - dependency-name: github.com/aws/aws-sdk-go
-    versions:
-    - 1.36.31
-    - 1.37.1
-    - 1.37.11
-    - 1.37.16
-    - 1.37.21
-    - 1.37.31
-    - 1.37.7
-    - 1.38.13
-    - 1.38.18
-    - 1.38.2
-    - 1.38.22
-    - 1.38.8
+  # 1. Go Modulesの依存関係を管理
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Goモジュールの更新を "go-modules" グループのPRにまとめる
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+
+  # 2. Dockerイメージの依存関係を管理 (docker-compose.yml, Dockerfile)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Dockerイメージの更新を "docker-images" グループのPRにまとめる
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+
+  # 3. GitHub Actionsの依存関係を管理
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # GitHub Actionsの更新を "github-actions" グループのPRにまとめる
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Go CI
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: false
+
+    - name: Start services with Docker Compose
+      run: docker compose up -d s3 kinesis
+
+    - name: Run tests
+      run: |
+        docker compose run --rm minio-mc
+        go test -race -v ./...
+      env:
+        AWS_REGION: ap-northeast-1
+        AWS_ACCESS_KEY_ID: XXXXXXXX
+        AWS_SECRET_ACCESS_KEY: YYYYYYYY
+        S3_ENDPOINT: http://localhost:9000
+        KINESIS_ENDPOINT: http://localhost:4567

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,23 @@ services:
     volumes:
       - minio:/data
     environment:
-      - MINIO_ACCESS_KEY=XXXXXXXX
-      - MINIO_SECRET_KEY=YYYYYYYY
+      - MINIO_ACCESS_KEY=toyhose
+      - MINIO_SECRET_KEY=toyhose_pw
     command: server /data
+  minio-mc:
+    image: minio/mc:latest
+    depends_on:
+      - s3
+    entrypoint: >
+      /bin/sh -c "
+        /usr/bin/mc ls myminio;
+        # ----- alias の作成 -----;
+        until /usr/bin/mc alias set myminio http://s3:9000 toyhose toyhose_pw; do echo '...waiting...' && sleep 1; done;
+        # ----- access key の作成 (sdk で使用) -----;
+        /usr/bin/mc admin user svcacct add --access-key 'XXXXXXXX' --secret-key 'YYYYYYYY' myminio toyhose;
+
+        exit 0;
+      "
   kinesis:
     image: instructure/kinesalite
     environment:


### PR DESCRIPTION
This pull request introduces several updates to improve dependency management, CI workflows, and Docker Compose configurations. The changes include restructuring the Dependabot configuration for better organization, adding a new GitHub Actions workflow for Go CI, and enhancing Docker Compose services with a new `minio-mc` service for MinIO alias creation and access key setup.

### Dependency Management Updates:
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L3-R34): Refactored to manage dependencies for Go modules, Docker images, and GitHub Actions separately, with daily update schedules and grouped pull requests for each type.

### CI Workflow Enhancements:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R32): Added a new GitHub Actions workflow for Go CI, which includes steps for code checkout, Go setup, Docker Compose service initialization, and running tests with environment variables configured for AWS and local services.

### Docker Compose Configuration Improvements:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L11-R27): Added a new `minio-mc` service to handle MinIO alias creation and access key setup, replacing hardcoded credentials with dynamically created ones. Updated `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` for the `s3` service.